### PR TITLE
Fix /actuator/health endpoint

### DIFF
--- a/invoices/build.gradle
+++ b/invoices/build.gradle
@@ -4,7 +4,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-quartz'
     implementation 'com.google.code.findbugs:jsr305:3.0.2'
-    implementation 'org.springframework.boot:spring-boot-starter-amqp'
     implementation 'org.jetbrains:annotations:19.0.0'
     implementation 'org.javamoney:moneta:1.4.2'
     implementation 'org.json:json:20201115'

--- a/kyc/build.gradle
+++ b/kyc/build.gradle
@@ -2,7 +2,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-quartz'
-    implementation 'org.springframework.boot:spring-boot-starter-amqp'
     implementation 'commons-collections:commons-collections:3.2.2'
     implementation 'com.google.code.gson:gson:2.8.5'
     compileOnly 'org.projectlombok:lombok'

--- a/notifications/build.gradle
+++ b/notifications/build.gradle
@@ -1,7 +1,6 @@
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-amqp'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation('org.springframework.boot:spring-boot-starter-test') {

--- a/sellers/build.gradle
+++ b/sellers/build.gradle
@@ -3,7 +3,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-quartz'
-    implementation 'org.springframework.boot:spring-boot-starter-amqp'
     implementation 'commons-collections:commons-collections:3.2.2'
 
     //Database config


### PR DESCRIPTION
With the `spring-boot-starter-amqp` dependencies still present, the health endpoint for the service won't work because it'll try to connect to RabbitMQ.