### PR TITLE
[ISSUE-126] Allowing confirm linked documents to be supplied to Mirak…

### DIFF
--- a/buildSrc/src/main/groovy/hmc.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/hmc.java-conventions.gradle
@@ -21,6 +21,7 @@ java {
 }
 
 repositories {
+	maven { url "https://nexus.k8s.an.digikfplc.com/repository/maven-public/" }
 	mavenCentral()
 	maven {
 		credentials {

--- a/buildSrc/src/main/groovy/hmc.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/hmc.java-conventions.gradle
@@ -21,7 +21,6 @@ java {
 }
 
 repositories {
-	maven { url "https://nexus.k8s.an.digikfplc.com/repository/maven-public/" }
 	mavenCentral()
 	maven {
 		credentials {

--- a/buildSrc/src/main/groovy/hmc.lib-conventions.gradle
+++ b/buildSrc/src/main/groovy/hmc.lib-conventions.gradle
@@ -10,5 +10,5 @@ bootJar {
 
 dependencies {
 	api 'com.hyperwallet:sdk:2.4.3'
-	api 'com.mirakl:mmp-sdk-operator:6.37.0'
+	api 'com.mirakl:mmp-sdk-operator:7.0.0'
 }

--- a/docs/content/modules/configuration/pages/configvars/configvars-notifications.adoc
+++ b/docs/content/modules/configuration/pages/configvars/configvars-notifications.adoc
@@ -14,6 +14,11 @@
 |Whether or not Hyperwallet notifications should be retried when an error occurs (e.g. connection issues). If set to `true`, any notification that fails is stored in the database and automatically restarted up to `PAYPAL_HYPERWALLET_MAX_AMOUNT` `_OF_NOTIFICATION_RETRIES` times. If set to `false`, notifications are not stored or retried
 |Possible values:`true` or `false`
 
+|`PAYPAL_HYPERWALLET_CONFIRM_LINKED_DOCUMENTS`
+|NO (default value: `false`)
+|Whether or not to confirm linked documents from an invoice (manual invoice confirmation).
+|Possible values:`true` or `false`
+
 |`PAYPAL_HYPERWALLET_MAX_AMOUNT_OF_NOTIFICATION_RETRIES`
 |NO (default value: `5`)
 |Sets the amount of retries a Hyperwallet notification operation can be retried before it is discarded. Whenever a notification is discarded, an email is sent to the integrators so it can be analyzed and addressed

--- a/docs/content/modules/reference/pages/notifications/notifications-retry.adoc
+++ b/docs/content/modules/reference/pages/notifications/notifications-retry.adoc
@@ -20,6 +20,8 @@ The connector reads the configuration from the following configuration variables
 
 * `PAYPAL_HYPERWALLET_RETRY_NOTIFICATIONS`, set to `true` to enable retries, or `false` to deactivate them. Set to `true` by default.
 
+* `PAYPAL_HYPERWALLET_CONFIRM_LINKED_DOCUMENTS`, set to `true` to allow confirmation of linked documents from an invoice (manual invoice confirmation). Set to `false` by default for backwards compatibility.
+
 * `PAYPAL_HYPERWALLET_MAX_AMOUNT_OF_NOTIFICATION_RETRIES`, determines the maximum number of attempts allowed for each notification. Set to `5` by default
 
 * `PAYPAL_HYPERWALLET_RETRY_FAILED_NOTIFICATIONS_CRON_EXPRESSION`, used to configure the periodicity of the retry job.

--- a/hmc-app/src/integrationTest/resources/application-test.properties
+++ b/hmc-app/src/integrationTest/resources/application-test.properties
@@ -20,3 +20,6 @@ hmc.hyperwallet.programs.userTokens                  = userToken
 hmc.hyperwallet.programs.paymentTokens               = paymentToken
 hmc.hyperwallet.programs.bankAccountTokens           = bankAccountToken
 hmc.hyperwallet.programs.rootToken                   = prg-1fb3df0d-787b-4bbd-9eb7-1d9fe8ed6c8e
+
+hmc.webhooks.payments.confirm-linked-documents       = false
+

--- a/hmc-app/src/main/resources/application.properties
+++ b/hmc-app/src/main/resources/application.properties
@@ -118,6 +118,7 @@ hmc.toggle-features.http-capture                     = ${PAYPAL_HYPERWALLET_HTTP
 
 hmc.webhooks.payments.failure-statuses               = FAILED,RECALLED,RETURNED,EXPIRED,UNCLAIMED,CANCELLED
 hmc.webhooks.payments.accepted-statuses              = COMPLETED
+hmc.webhooks.payments.confirm-linked-documents       = ${PAYPAL_HYPERWALLET_CONFIRM_LINKED_DOCUMENTS:false}
 hmc.webhooks.routing-keys.payments                   = PAYMENTS
 hmc.webhooks.routing-keys.kyc-users                  = USERS.UPDATED.VERIFICATION_STATUS
 hmc.webhooks.routing-keys.kyc-bstk                   = USERS.BUSINESS_STAKEHOLDERS

--- a/hmc-invoices/src/main/java/com/paypal/invoices/paymentnotifications/configuration/PaymentNotificationConfig.java
+++ b/hmc-invoices/src/main/java/com/paypal/invoices/paymentnotifications/configuration/PaymentNotificationConfig.java
@@ -19,4 +19,7 @@ public class PaymentNotificationConfig {
 	@Value("#{'${hmc.webhooks.payments.accepted-statuses}'}")
 	private Set<String> acceptedStatuses;
 
+	@Value("#{'${hmc.webhooks.payments.confirm-linked-documents}'}")
+	private boolean confirmLinkedDocuments;
+
 }

--- a/hmc-invoices/src/main/java/com/paypal/invoices/paymentnotifications/services/AcceptedPaymentNotificationStrategy.java
+++ b/hmc-invoices/src/main/java/com/paypal/invoices/paymentnotifications/services/AcceptedPaymentNotificationStrategy.java
@@ -62,6 +62,8 @@ public class AcceptedPaymentNotificationStrategy implements Strategy<PaymentNoti
 		miraklAccountingDocumentPaymentConfirmation
 				.setTransactionDate(DateUtil.convertToDate(paymentNotificationBodyModel.getCreatedOn(),
 						HyperWalletConstants.HYPERWALLET_DATE_FORMAT, DateUtil.TIME_UTC));
+		miraklAccountingDocumentPaymentConfirmation
+				.setConfirmLinkedManualDocuments(paymentNotificationConfig.isConfirmLinkedDocuments());
 
 		log.info("Creating payment confirmation request for invoice ID {} and amount {}",
 				miraklAccountingDocumentPaymentConfirmation.getInvoiceId(),

--- a/hmc-invoices/src/test/java/com/paypal/invoices/paymentnotifications/services/AcceptedPaymentNotificationStrategyTest.java
+++ b/hmc-invoices/src/test/java/com/paypal/invoices/paymentnotifications/services/AcceptedPaymentNotificationStrategyTest.java
@@ -77,6 +77,35 @@ class AcceptedPaymentNotificationStrategyTest {
 		assertThat(accountingDocuments.get(0).getCurrencyIsoCode()).isEqualTo(MiraklIsoCurrencyCode.EUR);
 		assertThat(accountingDocuments.get(0).getTransactionDate()).isEqualTo(DateUtil.convertToDate(CREATED_ON,
 				HyperWalletConstants.HYPERWALLET_DATE_FORMAT, TimeZone.getTimeZone("UTC")));
+		assertThat(accountingDocuments.get(0).isConfirmLinkedManualDocuments()).isFalse();
+	}
+
+	@Test
+	void execute_shouldSendConfirmationPaymentToMiraklConfirmingLinkedDocuments() {
+		when(paymentNotificationConfigMock.isConfirmLinkedDocuments()).thenReturn(true);
+
+		when(paymentNotificationBodyModelMock.getAmount()).thenReturn(AMOUNT);
+		when(paymentNotificationBodyModelMock.getClientPaymentId()).thenReturn(INVOICE_ID);
+		when(paymentNotificationBodyModelMock.getCurrency()).thenReturn(CURRENCY_EUR_ISO_CODE);
+		when(paymentNotificationBodyModelMock.getCreatedOn()).thenReturn(CREATED_ON);
+
+		testObj.execute(paymentNotificationBodyModelMock);
+
+		verify(miraklClientMock).confirmAccountingDocumentPayment(
+				miraklConfirmAccountingDocumentPaymentRequestArgumentCaptor.capture());
+
+		final MiraklConfirmAccountingDocumentPaymentRequest miraklConfirmAccountingDocumentPaymentRequest = miraklConfirmAccountingDocumentPaymentRequestArgumentCaptor
+				.getValue();
+		final List<MiraklAccountingDocumentPaymentConfirmation> accountingDocuments = miraklConfirmAccountingDocumentPaymentRequest
+				.getAccountingDocuments();
+
+		assertThat(miraklConfirmAccountingDocumentPaymentRequest.getAccountingDocuments()).hasSize(1);
+		assertThat(accountingDocuments.get(0).getAmount()).isEqualTo(AMOUNT);
+		assertThat(accountingDocuments.get(0).getInvoiceId()).isEqualTo(Long.valueOf(INVOICE_ID));
+		assertThat(accountingDocuments.get(0).getCurrencyIsoCode()).isEqualTo(MiraklIsoCurrencyCode.EUR);
+		assertThat(accountingDocuments.get(0).getTransactionDate()).isEqualTo(DateUtil.convertToDate(CREATED_ON,
+				HyperWalletConstants.HYPERWALLET_DATE_FORMAT, TimeZone.getTimeZone("UTC")));
+		assertThat(accountingDocuments.get(0).isConfirmLinkedManualDocuments()).isTrue();
 	}
 
 	@Test

--- a/hmc-observability/build.gradle
+++ b/hmc-observability/build.gradle
@@ -9,7 +9,7 @@ dependencies {
 
 	inpath 'org.apache.httpcomponents:httpclient'
 	inpath 'com.hyperwallet:sdk:2.4.3'
-	inpath 'com.mirakl:mmp-sdk-operator:6.37.0'
+	inpath 'com.mirakl:mmp-sdk-operator:7.0.0'
 
 	testImplementation project(":hmc-testsupport")
 }

--- a/hmc-testsupport/src/main/resources/application-test.properties
+++ b/hmc-testsupport/src/main/resources/application-test.properties
@@ -103,6 +103,7 @@ hmc.toggle-features.http-capture                     = ${PAYPAL_HYPERWALLET_HTTP
 
 hmc.webhooks.payments.failure-statuses               = FAILED,RECALLED,RETURNED,EXPIRED,UNCLAIMED,CANCELLED
 hmc.webhooks.payments.accepted-statuses              = COMPLETED
+hmc.webhooks.payments.confirm-linked-documents       = false
 hmc.webhooks.routing-keys.payments                   = PAYMENTS
 hmc.webhooks.routing-keys.kyc-users                  = USERS.UPDATED.VERIFICATION_STATUS
 hmc.webhooks.routing-keys.kyc-bstk                   = USERS.BUSINESS_STAKEHOLDERS


### PR DESCRIPTION
This commit will allow the new feature of confirming manual invoices (Mirakl functionality)

There is a new SDK referenced (Version 7.0.0) of the Mirakl SDK which in the Confirm Accounting Documents offers a new flag to confirm any linked manual invoices.

In line with Mirakl - for backwards compatibility, this feature is defaulted to off (false) in the connector, but can be enabled by supplying the appropriate Environment variable (updated in the documentation)

Regards,
Russ