### PR TITLE
[ISSUE-147] - Allowing Language code to be used in Hyperwallet Create User Request

### DIFF
--- a/buildSrc/src/main/groovy/hmc.lib-conventions.gradle
+++ b/buildSrc/src/main/groovy/hmc.lib-conventions.gradle
@@ -10,5 +10,5 @@ bootJar {
 
 dependencies {
 	api 'com.hyperwallet:sdk:2.4.3'
-	api 'com.mirakl:mmp-sdk-operator:6.37.0'
+	api 'com.mirakl:mmp-sdk-operator:7.0.0'
 }

--- a/hmc-observability/build.gradle
+++ b/hmc-observability/build.gradle
@@ -9,7 +9,7 @@ dependencies {
 
 	inpath 'org.apache.httpcomponents:httpclient'
 	inpath 'com.hyperwallet:sdk:2.4.3'
-	inpath 'com.mirakl:mmp-sdk-operator:6.37.0'
+	inpath 'com.mirakl:mmp-sdk-operator:7.0.0'
 
 	testImplementation project(":hmc-testsupport")
 }

--- a/hmc-sellers/src/main/java/com/paypal/sellers/sellerextractioncommons/model/SellerModel.java
+++ b/hmc-sellers/src/main/java/com/paypal/sellers/sellerextractioncommons/model/SellerModel.java
@@ -70,7 +70,7 @@ public class SellerModel {
 
 	private final String postalCode;
 
-	private final String language;
+	private final Locale language;
 
 	private final String programToken;
 

--- a/hmc-sellers/src/main/java/com/paypal/sellers/sellerextractioncommons/services/converters/AbstractMiraklShopToSellerModelConverter.java
+++ b/hmc-sellers/src/main/java/com/paypal/sellers/sellerextractioncommons/services/converters/AbstractMiraklShopToSellerModelConverter.java
@@ -3,6 +3,7 @@ package com.paypal.sellers.sellerextractioncommons.services.converters;
 import com.mirakl.client.mmp.domain.common.MiraklAdditionalFieldValue;
 import com.mirakl.client.mmp.domain.shop.MiraklContactInformation;
 import com.mirakl.client.mmp.domain.shop.MiraklShop;
+import com.mirakl.client.mmp.domain.shop.billing.MiraklDefaultBillingInformation;
 import com.paypal.infrastructure.support.strategy.Strategy;
 import com.paypal.infrastructure.support.strategy.StrategyExecutor;
 import com.paypal.sellers.bankaccountextraction.model.BankAccountModel;
@@ -26,6 +27,7 @@ public abstract class AbstractMiraklShopToSellerModelConverter implements Strate
 
 	protected SellerModel.SellerModelBuilder getCommonFieldsBuilder(final MiraklShop source) {
 		final MiraklContactInformation contactInformation = source.getContactInformation();
+		final MiraklDefaultBillingInformation defaultBillingInformation = source.getDefaultBillingInformation();
 		final List<MiraklAdditionalFieldValue> additionalFieldValues = source.getAdditionalFieldValues();
 		final BankAccountModel bankAccountModel = miraklShopBankAccountModelStrategyExecutor.execute(source);
 		//@formatter:off
@@ -43,6 +45,7 @@ public abstract class AbstractMiraklShopToSellerModelConverter implements Strate
 				.postalCode(contactInformation.getZipCode())
 				.stateProvince(contactInformation.getState())
 				.country(contactInformation.getCountry())
+				.language(defaultBillingInformation.getDefaultLanguage())
 				.timeZone(sellersMiraklApiConfig.getTimeZone())
 				.dateOfBirth(additionalFieldValues)
 				.passportId(additionalFieldValues)

--- a/hmc-sellers/src/main/java/com/paypal/sellers/sellerextractioncommons/services/converters/SellerModelToHyperWalletUserConverter.java
+++ b/hmc-sellers/src/main/java/com/paypal/sellers/sellerextractioncommons/services/converters/SellerModelToHyperWalletUserConverter.java
@@ -10,6 +10,8 @@ import org.springframework.stereotype.Service;
 
 import java.util.Optional;
 
+import static com.paypal.sellers.utils.LanguageConversion.toIso6391;
+
 @Service
 public class SellerModelToHyperWalletUserConverter implements Converter<SellerModel, HyperwalletUser> {
 
@@ -42,6 +44,7 @@ public class SellerModelToHyperWalletUserConverter implements Converter<SellerMo
 		hyperwalletUser.setCity(sellerModel.getCity());
 		hyperwalletUser.setStateProvince(sellerModel.getStateProvince());
 		hyperwalletUser.setPostalCode(sellerModel.getPostalCode());
+		hyperwalletUser.setLanguage(toIso6391(sellerModel.getLanguage()));
 		hyperwalletUser.setCountry(sellerModel.getCountry());
 		hyperwalletUser.setProgramToken(hyperwalletProgramsConfiguration
 				.getProgramConfiguration(sellerModel.getHyperwalletProgram()).getUsersProgramToken());

--- a/hmc-sellers/src/main/java/com/paypal/sellers/utils/LanguageConversion.java
+++ b/hmc-sellers/src/main/java/com/paypal/sellers/utils/LanguageConversion.java
@@ -1,0 +1,22 @@
+package com.paypal.sellers.utils;
+
+import java.util.Locale;
+
+public final class LanguageConversion {
+
+	private LanguageConversion() {
+	}
+
+	/**
+	 * Hyperwallet require that the language code be in ISO-639-1 format.
+	 * @param input - the input string of locale (e.g. en_GB)
+	 * @return the 2 digit language tag
+	 * @see <a href=
+	 * "https://docs.hyperwallet.com/content/references/v1/supported-languages">Supported
+	 * Languages</a>
+	 */
+	public static String toIso6391(final Locale input) {
+		return input != null ? input.getLanguage() : null;
+	}
+
+}

--- a/hmc-sellers/src/test/java/com/paypal/sellers/sellerextractioncommons/model/SellerModelTest.java
+++ b/hmc-sellers/src/test/java/com/paypal/sellers/sellerextractioncommons/model/SellerModelTest.java
@@ -14,6 +14,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Stream;
 
 import static com.paypal.sellers.sellerextractioncommons.model.SellerModelConstants.HYPERWALLET_TERMS_CONSENT;
@@ -231,7 +232,7 @@ class SellerModelTest {
 				.stateProvince("stateProvince")
 				.country("USA")
 				.postalCode("postalCode")
-				.language("language")
+				.language(Locale.US)
 				.programToken("programToken")
 				.businessType(List.of(businessTypeMiraklCustomField))
 				.businessName("businessName").token("token")
@@ -263,7 +264,7 @@ class SellerModelTest {
 				.hasFieldOrPropertyWithValue("stateProvince", "stateProvince")
 				.hasFieldOrPropertyWithValue("country", "US")
 				.hasFieldOrPropertyWithValue("postalCode", "postalCode")
-				.hasFieldOrPropertyWithValue("language", "language")
+				.hasFieldOrPropertyWithValue("language", Locale.US)
 				.hasFieldOrPropertyWithValue("programToken", "programToken")
 				.hasFieldOrPropertyWithValue("businessType", SellerBusinessType.CORPORATION)
 				.hasFieldOrPropertyWithValue("profileType", SellerProfileType.INDIVIDUAL)
@@ -489,7 +490,7 @@ class SellerModelTest {
 				.stateProvince("stateProvince")
 				.country("USA")
 				.postalCode("postalCode")
-				.language("language")
+				.language(Locale.US)
 				.programToken("programToken")
 				.businessType(List.of(businessTypeMiraklCustomField))
 				.businessName("businessName").token("token")

--- a/hmc-sellers/src/test/java/com/paypal/sellers/sellerextractioncommons/model/SellerModelTest.java
+++ b/hmc-sellers/src/test/java/com/paypal/sellers/sellerextractioncommons/model/SellerModelTest.java
@@ -1,10 +1,6 @@
 package com.paypal.sellers.sellerextractioncommons.model;
 
 import com.mirakl.client.mmp.domain.common.MiraklAdditionalFieldValue;
-import com.paypal.sellers.sellerextractioncommons.model.SellerBusinessType;
-import com.paypal.sellers.sellerextractioncommons.model.SellerGovernmentIdType;
-import com.paypal.sellers.sellerextractioncommons.model.SellerModel;
-import com.paypal.sellers.sellerextractioncommons.model.SellerProfileType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/hmc-sellers/src/test/java/com/paypal/sellers/sellerextractioncommons/services/converters/AbstractMiraklShopToIndividualSellerModelConverterTest.java
+++ b/hmc-sellers/src/test/java/com/paypal/sellers/sellerextractioncommons/services/converters/AbstractMiraklShopToIndividualSellerModelConverterTest.java
@@ -2,13 +2,13 @@ package com.paypal.sellers.sellerextractioncommons.services.converters;
 
 import com.mirakl.client.mmp.domain.shop.MiraklContactInformation;
 import com.mirakl.client.mmp.domain.shop.MiraklShop;
+import com.mirakl.client.mmp.domain.shop.billing.MiraklDefaultBillingInformation;
 import com.paypal.infrastructure.support.strategy.StrategyExecutor;
 import com.paypal.sellers.bankaccountextraction.model.BankAccountModel;
 import com.paypal.sellers.bankaccountextraction.model.IBANBankAccountModel;
 import com.paypal.sellers.sellerextractioncommons.configuration.SellersMiraklApiConfig;
 import com.paypal.sellers.sellerextractioncommons.model.SellerModel;
 import com.paypal.sellers.sellerextractioncommons.model.SellerModel.SellerModelBuilder;
-import com.paypal.sellers.sellerextractioncommons.services.converters.AbstractMiraklShopToSellerModelConverter;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -16,6 +16,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collections;
+import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -36,6 +37,9 @@ class AbstractMiraklShopToIndividualSellerModelConverterTest {
 	private MiraklContactInformation contactInformationMock;
 
 	@Mock
+	private MiraklDefaultBillingInformation defaultBillingInformationMock;
+
+	@Mock
 	private StrategyExecutor<MiraklShop, BankAccountModel> miraklShopBankAccountModelStrategyExecutor;
 
 	@Mock
@@ -47,6 +51,7 @@ class AbstractMiraklShopToIndividualSellerModelConverterTest {
 		when(miraklShopMock.getId()).thenReturn("shopId");
 		when(miraklShopMock.getName()).thenReturn("shopName");
 		when(miraklShopMock.getContactInformation()).thenReturn(contactInformationMock);
+		when(miraklShopMock.getDefaultBillingInformation()).thenReturn(defaultBillingInformationMock);
 		when(contactInformationMock.getFirstname()).thenReturn("firstName");
 		when(contactInformationMock.getLastname()).thenReturn("lastName");
 		when(contactInformationMock.getPhone()).thenReturn("phone");
@@ -58,6 +63,7 @@ class AbstractMiraklShopToIndividualSellerModelConverterTest {
 		when(contactInformationMock.getZipCode()).thenReturn("zipcode");
 		when(contactInformationMock.getState()).thenReturn("state");
 		when(contactInformationMock.getCountry()).thenReturn("USA");
+		when(defaultBillingInformationMock.getDefaultLanguage()).thenReturn(Locale.US);
 		// Not testing the builder part where it is converting and setting values from
 		// mirakl custom fields
 		when(miraklShopMock.getAdditionalFieldValues()).thenReturn(Collections.emptyList());
@@ -80,7 +86,8 @@ class AbstractMiraklShopToIndividualSellerModelConverterTest {
 				.hasFieldOrPropertyWithValue("postalCode", "zipcode")
 				.hasFieldOrPropertyWithValue("stateProvince", "state")
 				.hasFieldOrPropertyWithValue("country", "US")
-				.hasFieldOrPropertyWithValue("bankAccountDetails", IBANBankAccountModelMock);
+				.hasFieldOrPropertyWithValue("bankAccountDetails", IBANBankAccountModelMock)
+				.hasFieldOrPropertyWithValue("language", Locale.US);
 		//@formatter:on
 	}
 
@@ -90,6 +97,7 @@ class AbstractMiraklShopToIndividualSellerModelConverterTest {
 		when(miraklShopMock.getId()).thenReturn("shopId");
 		when(miraklShopMock.getName()).thenReturn("shopName");
 		when(miraklShopMock.getContactInformation()).thenReturn(contactInformationMock);
+		when(miraklShopMock.getDefaultBillingInformation()).thenReturn(defaultBillingInformationMock);
 		when(contactInformationMock.getFirstname()).thenReturn("firstName");
 		when(contactInformationMock.getLastname()).thenReturn("lastName");
 		when(contactInformationMock.getPhone()).thenReturn("phone");
@@ -101,6 +109,8 @@ class AbstractMiraklShopToIndividualSellerModelConverterTest {
 		when(contactInformationMock.getZipCode()).thenReturn("zipcode");
 		when(contactInformationMock.getState()).thenReturn("state");
 		when(contactInformationMock.getCountry()).thenReturn("USA");
+		when(defaultBillingInformationMock.getDefaultLanguage()).thenReturn(Locale.US);
+
 		// Not testing the builder part where it is converting and setting values from
 		// mirakl custom fields
 		when(miraklShopMock.getAdditionalFieldValues()).thenReturn(Collections.emptyList());
@@ -120,7 +130,9 @@ class AbstractMiraklShopToIndividualSellerModelConverterTest {
 				.hasFieldOrPropertyWithValue("postalCode", "zipcode")
 				.hasFieldOrPropertyWithValue("stateProvince", "state")
 				.hasFieldOrPropertyWithValue("country", "US")
-				.hasFieldOrPropertyWithValue("bankAccountDetails", null);
+				.hasFieldOrPropertyWithValue("bankAccountDetails", null)
+				.hasFieldOrPropertyWithValue("language", Locale.US);
+
 		//@formatter:on
 	}
 

--- a/hmc-sellers/src/test/java/com/paypal/sellers/sellerextractioncommons/services/converters/SellerModelToHyperWalletUserConverterTest.java
+++ b/hmc-sellers/src/test/java/com/paypal/sellers/sellerextractioncommons/services/converters/SellerModelToHyperWalletUserConverterTest.java
@@ -18,6 +18,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Date;
+import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.lenient;
@@ -49,6 +50,10 @@ class SellerModelToHyperWalletUserConverterTest {
 	private static final Date DATE_OF_BIRTH = DateUtil.convertToDate(LocalDate.of(1985, 9, 6), ZoneId.systemDefault());
 
 	private static final String COUNTRY_OF_NATIONALITY = "FRA";
+
+	private static final Locale SHOP_LANGUAGE = Locale.FRANCE;
+
+	private static final String HYPERWALET_LANGUAGE = "fr";
 
 	private static final String DRIVERS_LICENSE = "489663020J";
 
@@ -106,6 +111,7 @@ class SellerModelToHyperWalletUserConverterTest {
 		when(sellerModelMock.getPostalCode()).thenReturn(POSTAL_CODE);
 		when(sellerModelMock.getAddressLine1()).thenReturn(ADDRESS_LINE_ONE);
 		when(sellerModelMock.getCountry()).thenReturn(COUNTRY);
+		when(sellerModelMock.getLanguage()).thenReturn(SHOP_LANGUAGE);
 		when(sellerModelMock.getStateProvince()).thenReturn(STATE_PROVINCE);
 		when(sellerModelMock.getToken()).thenReturn(USER_TOKEN);
 		when(sellerModelMock.getEmail()).thenReturn(EMAIL);
@@ -136,8 +142,8 @@ class SellerModelToHyperWalletUserConverterTest {
 
 		assertThat(result).hasAllNullFieldsOrPropertiesExcept("clientUserId", "businessName", "profileType",
 				"businessType", "addressLine1", "city", "stateProvince", "postalCode", "programToken", "country",
-				"token", "inclusions", "email", "businessRegistrationCountry", "businessRegistrationStateProvince",
-				"businessRegistrationId", "businessOperatingName");
+				"token", "inclusions", "email", "language", "businessRegistrationCountry",
+				"businessRegistrationStateProvince", "businessRegistrationId", "businessOperatingName");
 		assertThat(result.getClientUserId()).isEqualTo(CLIENT_USER_ID);
 		assertThat(result.getBusinessName()).isEqualTo(BUSINESS_NAME);
 		assertThat(result.getBusinessOperatingName()).isEqualTo(COMPANY_NAME);
@@ -145,6 +151,7 @@ class SellerModelToHyperWalletUserConverterTest {
 		assertThat(result.getBusinessType()).isEqualTo(HyperwalletUser.BusinessType.PRIVATE_COMPANY);
 		assertThat(result.getAddressLine1()).isEqualTo(ADDRESS_LINE_ONE);
 		assertThat(result.getCity()).isEqualTo(CITY);
+		assertThat(result.getLanguage()).isEqualTo(HYPERWALET_LANGUAGE);
 		assertThat(result.getStateProvince()).isEqualTo(STATE_PROVINCE);
 		assertThat(result.getPostalCode()).isEqualTo(POSTAL_CODE);
 		assertThat(result.getProgramToken()).isEqualTo(PROGRAM_TOKEN);
@@ -166,8 +173,8 @@ class SellerModelToHyperWalletUserConverterTest {
 
 		assertThat(result).hasAllNullFieldsOrPropertiesExcept("clientUserId", "businessName", "profileType",
 				"businessType", "addressLine1", "city", "stateProvince", "postalCode", "programToken", "country",
-				"token", "inclusions", "email", "businessRegistrationCountry", "businessRegistrationStateProvince",
-				"businessRegistrationId", "businessOperatingName");
+				"token", "inclusions", "email", "language", "businessRegistrationCountry",
+				"businessRegistrationStateProvince", "businessRegistrationId", "businessOperatingName");
 		assertThat(result.getClientUserId()).isEqualTo(CLIENT_USER_ID);
 		assertThat(result.getBusinessName()).isEqualTo(COMPANY_NAME);
 		assertThat(result.getBusinessOperatingName()).isEqualTo(BUSINESS_NAME);
@@ -175,6 +182,7 @@ class SellerModelToHyperWalletUserConverterTest {
 		assertThat(result.getBusinessType()).isEqualTo(HyperwalletUser.BusinessType.PRIVATE_COMPANY);
 		assertThat(result.getAddressLine1()).isEqualTo(ADDRESS_LINE_ONE);
 		assertThat(result.getCity()).isEqualTo(CITY);
+		assertThat(result.getLanguage()).isEqualTo(HYPERWALET_LANGUAGE);
 		assertThat(result.getStateProvince()).isEqualTo(STATE_PROVINCE);
 		assertThat(result.getPostalCode()).isEqualTo(POSTAL_CODE);
 		assertThat(result.getProgramToken()).isEqualTo(PROGRAM_TOKEN);
@@ -207,6 +215,7 @@ class SellerModelToHyperWalletUserConverterTest {
 		assertThat(result.getAddressLine1()).isEqualTo(ADDRESS_LINE_ONE);
 		assertThat(result.getAddressLine2()).isEqualTo(ADDRESS_LINE_TWO);
 		assertThat(result.getCity()).isEqualTo(CITY);
+		assertThat(result.getLanguage()).isEqualTo(HYPERWALET_LANGUAGE);
 		assertThat(result.getStateProvince()).isEqualTo(STATE_PROVINCE);
 		assertThat(result.getCountry()).isEqualTo(COUNTRY);
 		assertThat(result.getPostalCode()).isEqualTo(POSTAL_CODE);

--- a/hmc-sellers/src/test/java/com/paypal/sellers/utils/LanguageConversionTest.java
+++ b/hmc-sellers/src/test/java/com/paypal/sellers/utils/LanguageConversionTest.java
@@ -1,0 +1,22 @@
+package com.paypal.sellers.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+
+import static com.paypal.sellers.utils.LanguageConversion.toIso6391;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LanguageConversionTest {
+
+	@Test
+	public void convert_ShouldConvertLanguageTags() {
+		assertThat(toIso6391(Locale.UK)).isEqualTo("en");
+		assertThat(toIso6391(Locale.ENGLISH)).isEqualTo("en");
+		assertThat(toIso6391(Locale.FRANCE)).isEqualTo("fr");
+		assertThat(toIso6391(Locale.FRENCH)).isEqualTo("fr");
+		assertThat(toIso6391(new Locale("es", "ES"))).isEqualTo("es");
+		assertThat(toIso6391(null)).isEqualTo(null);
+	}
+
+}


### PR DESCRIPTION
Mirakl SDK 7.0.0 allows the default_billing_info (which contains the language/locale default for the shop to be be included on the S20 calls)
(see: https://help.mirakl.net/bundle/customers/page/topics/Connectors/SDK/java/java_downloads.htm)

This means that the seller model in the connector can now have the language code correctly mapped.
The value in the S20 call is essentially a Locale (en_US for example) however Hyperwallet require the language portion:

(see: https://docs.hyperwallet.com/content/references/v1/supported-languages)

This pull request is to map the Locale to the Seller Model and use the language code on the Create Seller/User request to Hyperwallet which will allow managed KYC emails to be sent to the Shop/Seller in their preferred language.


![Email_In_Different_Locale](https://github.com/paypal/mirakl-hyperwallet-connector/assets/104622039/2c7fc557-80d0-4dea-b971-c46b8365a4f2)

