### PR TITLE
[ISSUE-153] Expose Spring Boot default hikari and tomcat settings via env variables

### DIFF
--- a/hmc-app/src/main/resources/application.properties
+++ b/hmc-app/src/main/resources/application.properties
@@ -19,6 +19,29 @@ spring.datasource.password                           =password
 spring.jpa.generate-ddl                              = true
 spring.jpa.hibernate.ddl-auto                        = update
 
+###################
+# Tomcat Config   #
+###################
+
+server.tomcat.accept-count=${SERVER_TOMCAT_ACCEPT_COUNT:100}
+server.tomcat.max-connections=${SERVER_TOMCAT_MAX_CONNECTIONS:8192}
+server.tomcat.threads.max=${SERVER_TOMCAT_THREADS_MAX:200}
+server.tomcat.threads.min-spare=${SERVER_TOMCAT_THREADS_MIN_SPARE:10}
+server.tomcat.connection-timeout=${SERVER_TOMCAT_CONNECTION_TIMEOUT:20000}
+
+#################################
+# HikariCP Config               #
+#################################
+spring.datasource.hikari.maximum-pool-size=${DATASOURCE_HIKARI_MAXIMUM_POOL_SIZE:10}
+spring.datasource.hikari.minimum-idle=${DATASOURCE_HIKARI_MINIMUM_IDLE:10}
+spring.datasource.hikari.connection-timeout=${DATASOURCE_HIKARI_CONNECTION_TIMEOUT:30000}
+spring.datasource.hikari.idle-timeout=${DATASOURCE_HIKARI_IDLE_TIMEOUT:600000}
+spring.datasource.hikari.max-lifetime=${DATASOURCE_HIKARI_MAX_LIFETIME:1800000}
+spring.datasource.hikari.leak-detection-threshold=${DATASOURCE_HIKARI_LEAK_DETECTION_THRESHOLD:0}
+spring.datasource.hikari.auto-commit=${DATASOURCE_HIKARI_AUTO_COMMIT:true}
+spring.datasource.hikari.validation-timeout=${DATASOURCE_HIKARI_VALIDATION_TIMEOUT:5000}
+spring.datasource.hikari.initialization-fail-timeout=${DATASOURCE_HIKARI_INITIALIZATION_FAIL_TIMEOUT:1}
+
 ##########################
 # Mail Config properties #
 ##########################


### PR DESCRIPTION
By making the defaults explicit and configurable via environment variables,
users gain better visibility into the effective runtime configuration and
a safe, non-invasive way to tune performance when needed.

No runtime behaviour is changed — all values match Spring Boot defaults
unless explicitly overridden. This PR intentionally avoids introducing
any tuned values.

This change is based on observations from back-off related performance
issues (see issue #153), where implicit defaults made concurrency limits
harder to diagnose.



