### PR TITLE
[ISSUE-155] Fix for notifications with forever retry

### DIFF
--- a/hmc-notifications/src/main/java/com/paypal/notifications/failures/repositories/FailedNotificationInformationRepository.java
+++ b/hmc-notifications/src/main/java/com/paypal/notifications/failures/repositories/FailedNotificationInformationRepository.java
@@ -4,6 +4,9 @@ import com.paypal.notifications.storage.repositories.entities.NotificationInfoEn
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,4 +23,18 @@ public interface FailedNotificationInformationRepository extends JpaRepository<N
 
 	Page<NotificationInfoEntity> findByTypeAndTarget(Pageable pageable, String type, String target);
 
+	@Modifying
+	@Query("""
+        update NotificationInfoEntity n
+        set n.retryCounter = coalesce(n.retryCounter, 0) + 1
+        where n.notificationToken = :token
+    """)
+	int incrementRetryCounter(@Param("token") String token);
+
+	@Modifying
+	@Query("""
+        delete from NotificationInfoEntity n
+        where n.notificationToken = :token
+    """)
+	int deleteByNotificationToken(@Param("token") String token);
 }

--- a/hmc-notifications/src/main/java/com/paypal/notifications/failures/services/FailedNotificationRetryMarker.java
+++ b/hmc-notifications/src/main/java/com/paypal/notifications/failures/services/FailedNotificationRetryMarker.java
@@ -1,0 +1,31 @@
+package com.paypal.notifications.failures.services;
+
+import com.paypal.notifications.failures.repositories.FailedNotificationInformationRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional(propagation = Propagation.REQUIRES_NEW)
+public class FailedNotificationRetryMarker {
+
+    private final FailedNotificationInformationRepository repo;
+
+    public FailedNotificationRetryMarker(FailedNotificationInformationRepository repo) {
+        this.repo = repo;
+    }
+
+    public void incrementFailures(String token) {
+        repo.incrementRetryCounter(token);
+    }
+
+    public void markSucceededAndRemove(String token) {
+        repo.deleteByNotificationToken(token);
+    }
+
+    public void expireAndRemove(String token) {
+        repo.deleteByNotificationToken(token);
+    }
+}

--- a/hmc-notifications/src/main/java/com/paypal/notifications/failures/services/FailedNotificationServiceImpl.java
+++ b/hmc-notifications/src/main/java/com/paypal/notifications/failures/services/FailedNotificationServiceImpl.java
@@ -1,54 +1,78 @@
 package com.paypal.notifications.failures.services;
 
+import com.hyperwallet.clientsdk.HyperwalletException;
 import com.hyperwallet.clientsdk.model.HyperwalletWebhookNotification;
 import com.paypal.notifications.failures.connectors.NotificationsRepository;
 import com.paypal.notifications.failures.repositories.FailedNotificationInformationRepository;
 import com.paypal.notifications.incoming.services.NotificationProcessingService;
 import com.paypal.notifications.storage.repositories.entities.NotificationInfoEntity;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-
-import java.util.Objects;
-import java.util.stream.StreamSupport;
 
 @Slf4j
 @Service
 public class FailedNotificationServiceImpl implements FailedNotificationService {
 
 	private final NotificationsRepository notificationsRepository;
-
 	private final FailedNotificationInformationRepository failedNotificationInformationRepository;
-
 	private final NotificationProcessingService notificationProcessingService;
+	private final FailedNotificationRetryMarker retryMarker;
+
+	@Value("${hmc.webhooks.retries.max-retries:5}")
+	private int maxRetries;
 
 	public FailedNotificationServiceImpl(final NotificationsRepository notificationsRepository,
-			final FailedNotificationInformationRepository failedNotificationInformationRepository,
-			final NotificationProcessingService notificationProcessingService) {
+										 final FailedNotificationInformationRepository failedNotificationInformationRepository,
+										 final NotificationProcessingService notificationProcessingService,
+										 final FailedNotificationRetryMarker retryMarker) {
 		this.notificationsRepository = notificationsRepository;
 		this.failedNotificationInformationRepository = failedNotificationInformationRepository;
 		this.notificationProcessingService = notificationProcessingService;
+		this.retryMarker = retryMarker;
 	}
 
-	/**
-	 * {@inheritDoc}
-	 */
 	@Override
 	public void processFailedNotifications() {
 		final Iterable<NotificationInfoEntity> failedNotifications = failedNotificationInformationRepository.findAll();
-		//@formatter:off
-		StreamSupport.stream(failedNotifications.spliterator(), false)
-				.map(this::getNotificationToReprocess)
-				.filter(Objects::nonNull)
-				.forEach(notificationProcessingService::processNotification);
-		//@formatter:on
-	}
 
-	private HyperwalletWebhookNotification getNotificationToReprocess(
-			final NotificationInfoEntity failedNotificationInformationEntity) {
-		log.info("Reprocessing notification [{}]", failedNotificationInformationEntity.getNotificationToken());
-		return notificationsRepository.getHyperwalletWebhookNotification(
-				failedNotificationInformationEntity.getProgram(),
-				failedNotificationInformationEntity.getNotificationToken());
+		for (NotificationInfoEntity entity : failedNotifications) {
+			final String token = entity.getNotificationToken();
+			try {
+				log.info("Reprocessing notification [{}], retryCounter={}", token, entity.getRetryCounter());
+
+				Integer current = entity.getRetryCounter();
+				int currentRetries = current == null ? 0 : current;
+				if (currentRetries >= maxRetries) {
+					log.warn("Notification [{}] exceeded max retries ({}). Expiring.", token, maxRetries);
+					retryMarker.expireAndRemove(token);
+					continue;
+				}
+
+				HyperwalletWebhookNotification notification = notificationsRepository.getHyperwalletWebhookNotification(
+						entity.getProgram(),
+						token
+				);
+
+				notificationProcessingService.processNotification(notification);
+
+				// success -> delete so it doesn't come back in retry job
+				retryMarker.markSucceededAndRemove(token);
+
+			}
+			catch (Exception e) {
+				// fail -> always increment
+				retryMarker.incrementFailures(token);
+
+				// logging
+				if (e instanceof HyperwalletException hw) {
+					log.warn("Retry failed for token={} due to HyperwalletException: {}", token, hw.getMessage());
+				}
+				else {
+					log.warn("Retry failed for token={} due to {}", token, e.toString());
+				}
+			}
+		}
 	}
 
 }

--- a/hmc-notifications/src/main/java/com/paypal/notifications/incoming/services/NotificationProcessingServiceImpl.java
+++ b/hmc-notifications/src/main/java/com/paypal/notifications/incoming/services/NotificationProcessingServiceImpl.java
@@ -36,6 +36,12 @@ public class NotificationProcessingServiceImpl implements NotificationProcessing
 	 */
 	@Override
 	public void processNotification(final HyperwalletWebhookNotification incomingNotificationDTO) {
+		if (incomingNotificationDTO == null) {
+			log.warn(
+					"Skipping notification processing - incoming notification is null (likely deleted/missing in Hyperwallet).");
+			return;
+		}
+
 		final NotificationEntity notificationEntity = notificationConverter.convert(incomingNotificationDTO);
 
 		if (notificationEntityEvaluator.isProcessable(notificationEntity)) {

--- a/hmc-notifications/src/test/java/com/paypal/notifications/failures/services/FailedNotificationServiceImplTest.java
+++ b/hmc-notifications/src/test/java/com/paypal/notifications/failures/services/FailedNotificationServiceImplTest.java
@@ -10,10 +10,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -29,6 +33,9 @@ class FailedNotificationServiceImplTest {
 
 	@InjectMocks
 	private FailedNotificationServiceImpl testObj;
+
+	@Mock
+	private FailedNotificationRetryMarker retryMarkerMock;
 
 	@Mock
 	private NotificationsRepository notificationsRepositoryMock;
@@ -48,6 +55,7 @@ class FailedNotificationServiceImplTest {
 
 	@Test
 	void processFailedNotifications_whenFailedNotificationsExist_shouldProcessFailedNotifications_andSkipNotificationsThatCantBeFetched() {
+		ReflectionTestUtils.setField(testObj, "maxRetries", 5);
 		when(failedNotificationInformationRepositoryMock.findAll()).thenReturn(
 				List.of(notificationInfoEntity1Mock, notificationInfoEntity2Mock, notificationInfoEntity3Mock));
 		when(notificationInfoEntity1Mock.getNotificationToken()).thenReturn(TOKEN_1);
@@ -68,4 +76,40 @@ class FailedNotificationServiceImplTest {
 		verify(notificationProcessingServiceMock).processNotification(hyperwalletWebhookNotification2Mock);
 	}
 
+	@Test
+	void processFailedNotifications_whenMaxRetriesReached_shouldExpireAndSkipProcessing() {
+		ReflectionTestUtils.setField(testObj, "maxRetries", 0);
+
+		when(failedNotificationInformationRepositoryMock.findAll()).thenReturn(List.of(notificationInfoEntity1Mock));
+		when(notificationInfoEntity1Mock.getNotificationToken()).thenReturn(TOKEN_1);
+		when(notificationInfoEntity1Mock.getRetryCounter()).thenReturn(0);
+
+		testObj.processFailedNotifications();
+
+		verify(retryMarkerMock).expireAndRemove(TOKEN_1);
+		verifyNoInteractions(notificationsRepositoryMock);
+		verifyNoInteractions(notificationProcessingServiceMock);
+		verify(retryMarkerMock, never()).incrementFailures(anyString());
+		verify(retryMarkerMock, never()).markSucceededAndRemove(anyString());
+	}
+
+	@Test
+	void processFailedNotifications_whenRetryCounterIsNull_shouldTreatAsZeroAndProcess() {
+		ReflectionTestUtils.setField(testObj, "maxRetries", 5);
+
+		when(failedNotificationInformationRepositoryMock.findAll()).thenReturn(List.of(notificationInfoEntity1Mock));
+		when(notificationInfoEntity1Mock.getNotificationToken()).thenReturn(TOKEN_1);
+		when(notificationInfoEntity1Mock.getProgram()).thenReturn(PROGRAM_TOKEN);
+		when(notificationInfoEntity1Mock.getRetryCounter()).thenReturn(0);
+
+		when(notificationsRepositoryMock.getHyperwalletWebhookNotification(PROGRAM_TOKEN, TOKEN_1))
+				.thenReturn(hyperwalletWebhookNotification1Mock);
+
+		testObj.processFailedNotifications();
+
+		verify(notificationProcessingServiceMock).processNotification(hyperwalletWebhookNotification1Mock);
+		verify(retryMarkerMock).markSucceededAndRemove(TOKEN_1);
+		verify(retryMarkerMock, never()).expireAndRemove(anyString());
+		verify(retryMarkerMock, never()).incrementFailures(anyString());
+	}
 }


### PR DESCRIPTION
fix for issue #155 
This MR refactors and clarifies the retry handling logic for failed webhook notifications to make retry behaviour explicit, deterministic, and easier to maintain.


Hi @max6001 @adbame 🙂 
If you have a moment, could you please take a look at this PR?  I’d really appreciate your review.